### PR TITLE
Connected extension to cookie consent feature of upcoming PWA version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.1.0] 2023-07-08
+### Added
+- Support for PWA cookie consent feature. Widget initialization is postponed till users finished the consent process. When no "comfort" consent is given, the widget will not show up.
+
 ## [1.0.4] 2022-12-06
 ### Fixed
 - changed styling to fit devices with notch.

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,6 +1,6 @@
 {
   "id": "@shopgate-project/userlike",
-  "version": "1.1.0-beta.1",
+  "version": "1.1.0-beta.2",
   "components": [
     {
       "id": "Subscribers",

--- a/extension-config.json
+++ b/extension-config.json
@@ -1,6 +1,6 @@
 {
   "id": "@shopgate-project/userlike",
-  "version": "1.0.4",
+  "version": "1.1.0-beta.1",
   "components": [
     {
       "id": "Subscribers",

--- a/frontend/subscriptions.js
+++ b/frontend/subscriptions.js
@@ -11,8 +11,8 @@ let comfortCookiesAccepted$;
 let getAreStatisticsCookiesSet;
 
 try {
-  // Try to import cookie consent related modules. "required" is used since the currently deployed
-  // PWA might not have the features implemented yet.
+  // Try to import cookie consent related modules. "require()" is used since the currently deployed
+  // PWA might not have the required modules implemented yet.
 
   /* eslint-disable global-require */
   ({ comfortCookiesAccepted$ } = require('@shopgate/engage/tracking/streams'));

--- a/frontend/subscriptions.js
+++ b/frontend/subscriptions.js
@@ -14,10 +14,11 @@ try {
   // Try to import cookie consent related modules. "require()" is used since the currently deployed
   // PWA might not have the required modules implemented yet.
 
-  /* eslint-disable global-require, import/no-unresolved */
+  /* eslint-disable eslint-comments/no-unlimited-disable */
+  /* eslint-disable */
   ({ comfortCookiesAccepted$ } = require('@shopgate/engage/tracking/streams'));
   ({ getAreStatisticsCookiesAccepted } = require('@shopgate/engage/tracking/selectors'));
-  /* eslint-enable global-require, import/no-unresolved */
+  /* eslint-enable  */
 } catch (e) {
   // Configure fallbacks in case of an import error
   comfortCookiesAccepted$ = appDidStart$;

--- a/frontend/subscriptions.js
+++ b/frontend/subscriptions.js
@@ -7,31 +7,29 @@ import { SHEET_EVENTS } from '@shopgate/pwa-ui-shared/Sheet';
 import { sdkUrl, pagesWithoutWidget } from './config';
 import { getUserData } from './selectors';
 
+let comfortCookiesAccepted$;
+let getAreStatisticsCookiesSet;
+
+try {
+  // Try to import cookie consent related modules. "required" is used since the currently deployed
+  // PWA might not have the features implemented yet.
+
+  /* eslint-disable global-require */
+  ({ comfortCookiesAccepted$ } = require('@shopgate/engage/tracking/streams'));
+  ({ getAreStatisticsCookiesSet } = require('@shopgate/engage/tracking/selectors'));
+  /* eslint-enable global-require */
+} catch (e) {
+  // nothing to do here
+}
+
+// Prepare stream for extension initialization with fallback
+const initializeWidget$ = comfortCookiesAccepted$ || appDidStart$;
+// Prepare selector to determine if user tracking is allowed with fallback that always allows
+const getIsUserTrackingAllowed = getAreStatisticsCookiesSet || (() => true);
+
 export default (subscribe) => {
   const { style } = document.documentElement;
   let ready = false;
-
-  // "live chat" -> userlike-tab. "UM" -> #uslk-button
-  css.global('#userlike-tab, #uslk-button, div[id^="userlike-"] iframe', {
-    bottom: 'calc(16px + var(--tabbar-height) + var(--safe-area-inset-bottom) + var(--footer-height) ) !important',
-  });
-  css.global('#userlikeButtonContainer, div[id^="userlike-"]', {
-    display: 'var(--userlike-um-display) !important',
-  });
-
-  css.global('#userlike-popup#userlike-popup, #uslk-messenger#uslk-messenger, div[id^="userlike-"] iframe[title="Messenger"]', {
-    top: 'var(--safe-area-inset-top) !important',
-    paddingTop: 'var(--safe-area-inset-top) !important',
-    paddingBottom: 'calc(var(--safe-area-inset-bottom) * 2) !important',
-    background: 'rgb(34, 77, 143)',
-  });
-
-  css.global('#userlike.userlike-mobile.userlike-mobile #userlike-chat-content', {
-    bottom: 'max(60px, calc(var(--safe-area-inset-bottom) * 3))',
-  });
-  css.global('#userlike-chat-scroll-textarea#userlike-chat-scroll-textarea', {
-    bottom: 'var(--safe-area-inset-bottom)',
-  });
 
   // Flag to indicate if "live chat" or "unified messaging" is used
   let isUMWidget = false;
@@ -58,7 +56,29 @@ export default (subscribe) => {
     }
   };
 
-  subscribe(appDidStart$, ({ getState }) => {
+  subscribe(initializeWidget$, ({ getState }) => {
+    // "live chat" -> userlike-tab. "UM" -> #uslk-button
+    css.global('#userlike-tab, #uslk-button, div[id^="userlike-"] iframe', {
+      bottom: 'calc(16px + var(--tabbar-height) + var(--safe-area-inset-bottom) + var(--footer-height) ) !important',
+    });
+    css.global('#userlikeButtonContainer, div[id^="userlike-"]', {
+      display: 'var(--userlike-um-display) !important',
+    });
+
+    css.global('#userlike-popup#userlike-popup, #uslk-messenger#uslk-messenger, div[id^="userlike-"] iframe[title="Messenger"]', {
+      top: 'var(--safe-area-inset-top) !important',
+      paddingTop: 'var(--safe-area-inset-top) !important',
+      paddingBottom: 'calc(var(--safe-area-inset-bottom) * 2) !important',
+      background: 'rgb(34, 77, 143)',
+    });
+
+    css.global('#userlike.userlike-mobile.userlike-mobile #userlike-chat-content', {
+      bottom: 'max(60px, calc(var(--safe-area-inset-bottom) * 3))',
+    });
+    css.global('#userlike-chat-scroll-textarea#userlike-chat-scroll-textarea', {
+      bottom: 'var(--safe-area-inset-bottom)',
+    });
+
     if (!sdkUrl) {
       logger.warn('Userlike: No url configured');
       return;
@@ -105,7 +125,9 @@ export default (subscribe) => {
   });
 
   subscribe(userDataReceived$, ({ getState }) => {
-    if (!window.userlike || !ready) {
+    const isUserTrackingAllowed = getIsUserTrackingAllowed(getState());
+
+    if (!window.userlike || !ready || !isUserTrackingAllowed) {
       return;
     }
 
@@ -120,6 +142,10 @@ export default (subscribe) => {
   });
 
   subscribe(userDidLogout$, () => {
+    if (!window.userlike || !ready) {
+      return;
+    }
+
     window.userlike.setData({});
     window.userlike.userlikeUpdateAPI();
   });

--- a/frontend/subscriptions.js
+++ b/frontend/subscriptions.js
@@ -8,7 +8,7 @@ import { sdkUrl, pagesWithoutWidget } from './config';
 import { getUserData } from './selectors';
 
 let comfortCookiesAccepted$;
-let getAreStatisticsCookiesSet;
+let getAreStatisticsCookiesAccepted;
 
 try {
   // Try to import cookie consent related modules. "require()" is used since the currently deployed
@@ -16,7 +16,7 @@ try {
 
   /* eslint-disable global-require */
   ({ comfortCookiesAccepted$ } = require('@shopgate/engage/tracking/streams'));
-  ({ getAreStatisticsCookiesSet } = require('@shopgate/engage/tracking/selectors'));
+  ({ getAreStatisticsCookiesAccepted } = require('@shopgate/engage/tracking/selectors'));
   /* eslint-enable global-require */
 } catch (e) {
   // nothing to do here
@@ -25,7 +25,7 @@ try {
 // Prepare stream for extension initialization with fallback
 const initializeWidget$ = comfortCookiesAccepted$ || appDidStart$;
 // Prepare selector to determine if user tracking is allowed with fallback that always allows
-const getIsUserTrackingAllowed = getAreStatisticsCookiesSet || (() => true);
+const getIsUserTrackingAllowed = getAreStatisticsCookiesAccepted || (() => true);
 
 export default (subscribe) => {
   const { style } = document.documentElement;


### PR DESCRIPTION
This pull request adds support for the cookie consent feature of the upcoming PWA version. The chat widget will only be shown when "comfort" cookies are accepted.

When deployed with an old PWA version that doesn't support the cookie consent yet, the extension will work as before.

Since the cookie consent feature is not released yet, please use the CURB-2434-cookie-settings of the PWA repository for testing.